### PR TITLE
Add transaction retrieval via session/transaction ID

### DIFF
--- a/payments_przelewy24/api.py
+++ b/payments_przelewy24/api.py
@@ -158,3 +158,6 @@ class Przelewy24API:
         payload = asdict(verify)
         response = self._do("PUT", self._config.endpoints.transactionVerify, payload)
         return response["data"]["status"] == "success"
+
+    def get_by_session_id(self, *, session_id: str) -> dict:
+        return self._do("GET", self._config.endpoints.transactionGetBySessionId + session_id)

--- a/payments_przelewy24/config.py
+++ b/payments_przelewy24/config.py
@@ -12,6 +12,7 @@ P24_TEST_CONNECTION: str = "api/v1/testAccess"
 P24_TRANSACTION_REQUEST: str = "trnRequest"
 P24_TRANSACTION_REGISTER: str = "api/v1/transaction/register"
 P24_TRANSACTION_VERIFY: str = "api/v1/transaction/verify"
+P24_TRANSACTION_GET_BY_SESSION_ID: str = "/api/v1/transaction/by/sessionId/"
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,7 @@ class Endpoints:
     transactionRequest: str
     transactionRegister: str
     transactionVerify: str
+    transactionGetBySessionId: str
 
 
 @dataclass(init=False)
@@ -51,6 +53,7 @@ class Przelewy24Config:
             transactionRequest=f"{base_url}{P24_TRANSACTION_REQUEST}",
             transactionRegister=f"{base_url}{P24_TRANSACTION_REGISTER}",
             transactionVerify=f"{base_url}{P24_TRANSACTION_VERIFY}",
+            transactionGetBySessionId=f"{base_url}{P24_TRANSACTION_GET_BY_SESSION_ID}",
         )
 
     def generate_sign(self, **kwargs) -> str:


### PR DESCRIPTION
Adds a new API which allows getting P24 transaction details from its ID. While it's not used by django-payments directly, it can be used by apps to handle things like refunds, payment failure discovery, etc.